### PR TITLE
Add missing ski-lift types j-bar, platter and magic_carpet

### DIFF
--- a/Freizeitkarte-Entwicklung/style/fzk/lines-master
+++ b/Freizeitkarte-Entwicklung/style/fzk/lines-master
@@ -1829,12 +1829,16 @@ aerialway = cable_car | aerialway = gondola | aerialway = mixed_lift [0x011f1f r
 # t-bar: Ein T-foermiger Schlepplift fuer Skifahrer.
 # 0x11     = Bitmap 2 (transparent, nur fuer Routing, NoLabel)
 # 0x011f1e = Bitmap 4 (3 Pixel gefuellt, NoLabel)
-aerialway = chair_lift | aerialway = drag_lift | aerialway=t-bar [0x11 road_class=0 road_speed=0 resolution 24 continue]
-aerialway = chair_lift | aerialway = drag_lift | aerialway=t-bar [0x011f1e resolution 23]
+aerialway = chair_lift | aerialway = drag_lift | aerialway=t-bar | aerialway=j-bar | aerialway=platter [0x11 road_class=0 road_speed=0 resolution 24 continue]
+aerialway = chair_lift | aerialway = drag_lift | aerialway=t-bar | aerialway=j-bar | aerialway=platter [0x011f1e resolution 23]
 
 # rope-tow: A tow-line for skiers and riders. The passengers hold the rope by hand or use special tow grabbers (nutcrackers). 
 # 0x011f1e = Bitmap 4 (3 Pixel gefuellt, NoLabel)
 aerialway = rope_tow [0x011f1e resolution 23]
+
+# magic_carpet: A ski lift resembling a conveyor belt, usually used by  small children.
+# 0x011f1e = Bitmap 4 (3 Pixel gefuellt, NoLabel)
+aerialway = magic_carpet [0x011f1e resolution 23]
 
 # Materialseilbahn. Personentransport ist normalerweise nicht erlaubt.
 # 0x01210d = Bitmap 4 (3 Pixel gefuellt, NoLabel)


### PR DESCRIPTION
Aerialways do have a few more forms that are not rendered on the Freizeitkarte yet, cf. [Aerialway](https://wiki.openstreetmap.org/wiki/Aerialway)

Freizeitkarte (left) vs. Freizeitkarte from this lift-types feature brach (right):
![freizeitkarte](https://user-images.githubusercontent.com/4203035/50963454-0cf8e480-14cd-11e9-812f-23641b9c4238.png) ![freizeitkarte_lift-types](https://user-images.githubusercontent.com/4203035/50963472-15e9b600-14cd-11e9-8915-0acbc8d64480.png)

The lift that isn't shown on the left is an `aerialway=platter`.