### PR TITLE
fix NSIS:"warning 7998: ANSI targets are deprecated"

### DIFF
--- a/Freizeitkarte-Entwicklung/mt.pl
+++ b/Freizeitkarte-Entwicklung/mt.pl
@@ -3401,6 +3401,8 @@ sub create_nsis_nsi_full {
   printf { $fh } ( "; General Settings\n" );
   printf { $fh } ( "; ----------------\n" );
   printf { $fh } ( "\n" );
+  printf { $fh } ( "Unicode True" );
+  printf { $fh } ( "\n" );
   printf { $fh } ( "; Installationsverzeichnis (Default)\n" );
   printf { $fh } ( "!define INSTALLATIONS_VERZEICHNIS \"C:\\Freizeitkarte\\%s\"\n", $mapname );
   printf { $fh } ( "\n" );


### PR DESCRIPTION
NSIS: "warning 7998: ANSI targets are deprecated" lässt sich lösen durch hinzufügen von "Unicode True" in der .nsis-Datei